### PR TITLE
PLAT-887 | Cache users

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -17,6 +17,7 @@ type Client struct {
 
 	sessionId string
 	userAgent string
+	users     *Users
 }
 
 type LoginDetails struct {
@@ -49,20 +50,8 @@ func NewClient(l LoginDetails) (LoginSuccess, error) {
 	var sessionId string
 
 	// Re-use existing sessionId if possible
-	if l.SessionId != "" {
-		log.Printf("[DEBUG] Checking if existing sessionId is valid")
-		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/user/current", l.Host), nil)
-		res, err := httpClient.Do(req)
-		if err != nil {
-			log.Printf("[WARN] Error fetching current user: %s", err)
-		}
-		defer res.Body.Close()
-
-		if res.StatusCode == http.StatusOK {
-			// Session Id is valid
-			sessionId = l.SessionId
-		}
-	}
+	// Session Id is valid
+	sessionId = loginWithSessionId(l, httpClient, sessionId)
 
 	if sessionId == "" { // Login with username/password
 		log.Printf("[DEBUG] Logging in with username/password")
@@ -102,6 +91,24 @@ func NewClient(l LoginDetails) (LoginSuccess, error) {
 		},
 		SessionId: sessionId,
 	}, nil
+}
+
+func loginWithSessionId(l LoginDetails, httpClient *http.Client, sessionId string) string {
+	if l.SessionId != "" {
+		log.Printf("[DEBUG] Checking if existing sessionId is valid")
+		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/user/current", l.Host), nil)
+		res, err := httpClient.Do(req)
+		if err != nil {
+			log.Printf("[WARN] Error fetching current user: %s", err)
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode == http.StatusOK {
+
+			sessionId = l.SessionId
+		}
+	}
+	return sessionId
 }
 
 func (c *Client) sendRequest(req *http.Request, v interface{}) error {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,11 +2,12 @@ package client
 
 import (
 	"encoding/json"
-	"github.com/hashicorp/go-uuid"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/hashicorp/go-uuid"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLogin(t *testing.T) {

--- a/client/user.go
+++ b/client/user.go
@@ -24,6 +24,9 @@ type Users struct {
 }
 
 func (c *Client) GetUsers() (Users, error) {
+	if c.users != nil {
+		return *c.users, nil
+	}
 	url := fmt.Sprintf("%s/api/user", c.BaseURL)
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	users := Users{}
@@ -35,6 +38,7 @@ func (c *Client) GetUsers() (Users, error) {
 	}
 
 	log.Printf("[DEBUG] Got users '%+v'", users)
+	c.users = &users
 	return users, nil
 }
 

--- a/client/user_test.go
+++ b/client/user_test.go
@@ -131,4 +131,28 @@ func TestUser(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, expected, us)
 	})
+
+	t.Run("Get users & cache them so that subsequent calls are not making network call", func(t *testing.T) {
+		email := "test@example.com"
+		expected := Users{
+			Data: []User{{
+				Id:    1,
+				Email: email,
+			}},
+		}
+		httpMethod := http.MethodGet
+		svr := server("/api/user", httpMethod, expected)
+
+		c := Client{
+			BaseURL:    svr.URL,
+			HTTPClient: &http.Client{},
+		}
+		orig, errOrig := c.GetUsers()
+		svr.Close() // close so the mock server is not running
+		later, errLater := c.GetUsers()
+
+		assert.Nil(t, errOrig)
+		assert.Nil(t, errLater)
+		assert.Equal(t, orig, later)
+	})
 }


### PR DESCRIPTION
Finding by email is a common case but [Metabase API](https://www.metabase.com/docs/latest/api-documentation.html) doesn't support it. Fetching the entire user list each time over the network would be very expensive within the same run. This will cache the users in memory for a particular run.

A future improvement could be to keep a map of `email -> user` so that we can avoid iterating in memory. However, that would mean touching other parts of the code & is a smaller improvement.