### PR TITLE
Expiration date for group membership

### DIFF
--- a/metabase/resource_membership.go
+++ b/metabase/resource_membership.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 	"terraform-provider-metabase/client"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -33,6 +34,11 @@ func resourceMembership() *schema.Resource {
 				Type:     schema.TypeInt,
 				Required: true,
 				ForceNew: true,
+			},
+			"expiration": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
 			},
 		},
 	}
@@ -75,7 +81,7 @@ func resourceMembershipCreate(_ context.Context, d *schema.ResourceData, meta in
 	return
 }
 
-func resourceMembershipRead(_ context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
+func resourceMembershipRead(ctx context.Context, d *schema.ResourceData, meta interface{}) (diags diag.Diagnostics) {
 	membershipId, _ := strconv.Atoi(d.Id())
 
 	c := meta.(*client.Client)
@@ -101,7 +107,19 @@ func resourceMembershipRead(_ context.Context, d *schema.ResourceData, meta inte
 	if err := d.Set("membership_id", m.MembershipId); err != nil {
 		return diag.FromErr(err)
 	}
-
+	expirationDateStr, ok := d.GetOk("expiration_date")
+	if ok {
+		expirationDate, err := time.Parse(time.RFC3339, expirationDateStr.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		if time.Now().After(expirationDate) {
+			if diags := resourceMembershipDelete(ctx, d, meta); diags.HasError() {
+				return diags
+			}
+			d.SetId("")
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
**WHAT**

Add an expiration date to group membership so we can destroy memberships with expired access.

**WHY**
There are certain memberships we want to have time limits on. e.g providing access to PII data for people who do not need permanent access. Metabase doesn't provide this functionality natively so destroying the membership via terraform is an alternative.