### PR TITLE
Fix deprecated github-action step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,10 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2
+        uses: crazy-max/ghaction-import-gpg@v5
         env:
-          # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4


### PR DESCRIPTION
switch to `crazy-max/ghaction-import-gpg` as per recommendation in `/hashicorp/ghaction-import-gpg`

https://github.com/hashicorp/ghaction-import-gpg

<img width="811" alt="image" src="https://github.com/getmoss/terraform-provider-metabase/assets/84311571/28fe8a92-5837-4d02-8acb-804d840f4bcf">
