### PR TITLE
[PLAT-3184] - Add concurrency for branch.yaml

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    concurrency:
+      group: branch
+      cancel-in-progress: true
     timeout-minutes: 5
     steps:
 

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -4,12 +4,12 @@ on:
     paths-ignore:
       - '**.md'
 
+concurrency:
+  group: branch
+  cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-latest
-    concurrency:
-      group: branch
-      cancel-in-progress: true
     timeout-minutes: 5
     steps:
 


### PR DESCRIPTION
This PR introduces a concurrency limit to the branch builds. The changes ensure that only one build per branch is executed at a time, and any in-progress builds are canceled if a new build is triggered.
Tested: https://github.com/getmoss/document-fetcher/actions/runs/12031369777